### PR TITLE
Merge new reg expression into dev branch

### DIFF
--- a/example/reset-test.sh
+++ b/example/reset-test.sh
@@ -3,4 +3,24 @@ if [[ ${PWD##*/} != "example" ]]; then
   cd example
 fi
 
-echo "package test\n\nfunc \\Xi() {\n	return \`\\xi latex is \\pi \\phi\`\n}\n" > test-file.go
+echo 'package test
+
+func \\Xi() {
+  return \`\\xi latex is \\pi \\phi\`
+}
+
+func \\gammaDot() {
+  return \`\\gammaDot`
+}
+
+func Frat() {
+  return "\kappa\gamma\eta"
+
+func main() {
+  \\hbar_star := 0.0562
+  x := \\Xi()
+  y := \\gammaDot()
+
+}
+
+' > test-file.go

--- a/example/test-file.go
+++ b/example/test-file.go
@@ -1,6 +1,21 @@
 package test
 
 func Ξ() {
-	return `ξ latex is π φ`
+  return \`ξ latex is π φ\`
 }
+
+func γDot() {
+  return \`γDot`
+}
+
+func Frat() {
+  return "κγη"
+
+func main() {
+  ℏ_star := 0.0562
+  x := Ξ()
+  y := γDot()
+
+}
+
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
     }
 
   } else {
-    
+
     if fileExists(fileArg) && filepath.Ext(fileArg) == `.go` {
       files = append(files, fileArg)
 
@@ -55,10 +55,10 @@ func main() {
       log.Println("An Error occured reading %s", err)
       continue
     }
-    
+
     fmt.Println(`Processing file:`, file)
     updatedText := process(string(contents))
-    
+
     err = ioutil.WriteFile(file, []byte(updatedText), 0644)
     if err != nil {
       log.Fatalln(err)
@@ -69,7 +69,7 @@ func main() {
 // process takes the text from the source file, regexes it for LaTeX commands
 // 
 func process(text string) string {
-  regex := regexp.MustCompile(`\\\w+`)
+  regex := regexp.MustCompile(`\\[A-Za-z][a-z]*[a-z]`)
   var unicodedText []string
 
   for _, line := range strings.Split(text, `\n`) {
@@ -79,7 +79,7 @@ func process(text string) string {
       latexCmd := text[loc[0]:loc[1]]
       unicodeString := ref.Chart[latexCmd]
 
-      line = strings.Replace(line, latexCmd, unicodeString, -1)      
+      line = strings.Replace(line, latexCmd, unicodeString, -1)
     }
 
     unicodedText = append(unicodedText, line)


### PR DESCRIPTION
I changed the regex to allow better matching of variable names.

A variable can now contain LaTeX macros provided the following character is one of the following:
- A backslash i.e. another LaTeX macro
- An underscore
- A space
- Or a Capital letter

The only kind of character that cannot follow a macro is a lowercase letter! 